### PR TITLE
Add Trust Wallet docs

### DIFF
--- a/docs/pages/permissionless/how-to/accounts/support.mdx
+++ b/docs/pages/permissionless/how-to/accounts/support.mdx
@@ -1,6 +1,6 @@
 # Account Support
 
-permissionless.js supports 5 types of accounts natively (but can easily be extended to support any compatible ERC-4337 account). The below table details which EntryPoints each account is valid for.
+permissionless.js supports 6 types of accounts natively (but can easily be extended to support any compatible ERC-4337 account). The below table details which EntryPoints each account is valid for.
 
 | Account       | EntryPoint v0.7   | EntryPoint v0.6 |
 | :------       | :------ | :------ |
@@ -9,3 +9,4 @@ permissionless.js supports 5 types of accounts natively (but can easily be exten
 | Kernel        | ✅      | ✅ |
 | Biconomy      | ❌      | ✅ |
 | LightAccount  | ❌      | ✅ |
+| TrustWallet   | ❌      | ✅ |

--- a/docs/pages/permissionless/how-to/accounts/use-trustwallet-account.mdx
+++ b/docs/pages/permissionless/how-to/accounts/use-trustwallet-account.mdx
@@ -1,0 +1,75 @@
+# How to create and use a Trust smart account with permissionless.js
+
+:::info
+[Trust Wallet](https://trustwallet.com/), the author of [Barz](https://github.com/trustwallet/barz), provides a smart contract security monitoring service for each and every Barz deployed on-chain including Barz created by SDK.
+This is a service that TrustWallet provides to builders to build innovative products on top of a secure foundation.
+Monitoring will automatically start as soon as the Barz account is deployed on-chain; for projects wanting to get security monitoring information, reach out to the smart wallet channel in [TrustWallet Discord](https://discord.gg/trustwallet).
+:::
+
+Trust Wallet is one of the most trusted wallet provider empowering more than 122 million users and is the first Web3 wallet to be [certified by ISO](https://trustwallet.com/security).
+After thorough development and extensive security audits, Trust Wallet launched the [Smart Wallet](https://trustwallet.com/swift) powered by account abstraction.
+
+With the recent opensource of their Smart Wallet system Barz, their smart account solution, together with their security infrastructure is disclosed for public to support builders build products on a secure foundation.
+
+This guide will walk you through how to create and use a Barz account with permissionless.js
+
+## Steps
+
+::::steps
+
+#### Import the required packages
+
+```ts
+// [!include ~/snippets/accounts/trustwallet.ts:imports]
+```
+
+### Create the clients
+
+First we must create the public, bundler, and (optionally) paymaster clients that will be used to interact with the Trust Smart Account.
+
+```ts
+// [!include ~/snippets/accounts/trustwallet.ts:clients]
+```
+
+
+### Create the TrustAccount
+
+:::info
+For a full list of options for creating a TrustAccount, take a look at the reference documentation page for [`signerToTrustSmartAccount`](/permissionless/reference/accounts/signerToTrustSmartAccount).
+:::
+
+You can also pass an `address` to use an already created TrustAccount.
+
+```ts
+// [!include ~/snippets/accounts/trustwallet.ts:smartAccount]
+```
+
+
+### Create the smart account client
+
+The smart account client is a permissionless.js client that is meant to serve as an almost drop-in replacement for viem's [walletClient](https://viem.sh/docs/clients/wallet.html).
+
+```ts
+// [!include ~/snippets/accounts/trustwallet.ts:smartAccountClient]
+```
+
+
+### Send a transaction
+
+Transactions using permissionless.js simply wrap around user operations. This means you can switch to permissionless.js from your existing viem EOA codebase with minimal-to-no changes.
+
+```ts
+// [!include ~/snippets/accounts/trustwallet.ts:submit]
+```
+
+This also means you can also use viem Contract instances to transact without any modifications.
+
+```ts
+// [!include ~/snippets/accounts/trustwallet.ts:submitNft]
+```
+
+You can also send an array of transactions in a single batch.
+
+```ts
+// [!include ~/snippets/accounts/trustwallet.ts:submitBatch]
+```

--- a/docs/pages/permissionless/how-to/signers/dynamic.mdx
+++ b/docs/pages/permissionless/how-to/signers/dynamic.mdx
@@ -42,7 +42,7 @@ export const App = () => {
 
 ### Create the SmartAccountClient
 
-Create the smart account client using the Dynamic signer. Note: DynamicWagmiConnector internally sets up the WagmiConfig, so there is no need to do it separately. This is where you would configure what smart account implementation (e.g. [Safe](/permissionless/how-to/accounts/use-safe-account), [Kernel](/permissionless/how-to/accounts/use-kernel-account), Biconomy, [SimpleAccount](/permissionless/how-to/accounts/use-simple-account)) and what paymaster logic you want to use.
+Create the smart account client using the Dynamic signer. Note: DynamicWagmiConnector internally sets up the WagmiConfig, so there is no need to do it separately. This is where you would configure what smart account implementation (e.g. [Safe](/permissionless/how-to/accounts/use-safe-account), [Kernel](/permissionless/how-to/accounts/use-kernel-account), Biconomy, [TrustWallet](/permissionless/how-to/accounts/use-trustwallet-account) [SimpleAccount](/permissionless/how-to/accounts/use-simple-account)) and what paymaster logic you want to use.
 
 ```ts
 import { createSmartAccountClient, walletClientToSmartAccountSigner } from "permissionless";

--- a/docs/pages/permissionless/how-to/signers/privy.mdx
+++ b/docs/pages/permissionless/how-to/signers/privy.mdx
@@ -53,7 +53,7 @@ useEffect(() => setActiveWallet(embeddedWallet), [embeddedWallet])
 
 ### Create the SmartAccountClient
 
-Create the smart account client using the Privy signer. This is where you would configure what smart account implementation (e.g. [Safe](/permissionless/how-to/accounts/use-safe-account), [Kernel](/permissionless/how-to/accounts/use-kernel-account), Biconomy, [SimpleAccount](/permissionless/how-to/accounts/use-simple-account)) and what paymaster logic you want to use.
+Create the smart account client using the Privy signer. This is where you would configure what smart account implementation (e.g. [Safe](/permissionless/how-to/accounts/use-safe-account), [Kernel](/permissionless/how-to/accounts/use-kernel-account), Biconomy, [TrustWallet](/permissionless/how-to/accounts/use-trustwallet-account), [SimpleAccount](/permissionless/how-to/accounts/use-simple-account)) and what paymaster logic you want to use.
 
 ```ts
 import { createSmartAccountClient, walletClientToSmartAccountSigner } from "permissionless";

--- a/docs/pages/permissionless/how-to/signers/smartAccounts.mdx
+++ b/docs/pages/permissionless/how-to/signers/smartAccounts.mdx
@@ -16,4 +16,8 @@
 // [!include ~/snippets/signers/accounts/biconomySmartAccount.ts:main]
 ```
 
+```ts [TrustWallet Account]
+// [!include ~/snippets/signers/accounts/trustSmartAccount.ts:main]
+```
+
 :::

--- a/docs/pages/permissionless/index.mdx
+++ b/docs/pages/permissionless/index.mdx
@@ -12,7 +12,7 @@ import { HomePage } from 'vocs/components'
   <h1 className='vocs_HomePage_title'>permissionless.js</h1>
   <HomePage.Tagline>Build with ERC-4337 smart accounts, bundlers, paymasters, and user operations</HomePage.Tagline>
   <HomePage.InstallPackage name="permissionless" type="install" />
-  <HomePage.Description>permissionless.js is a TypeScript library built on viem for building with ERC-4337 smart accounts, bundlers, paymasters, and user operations. The core focuses are avoiding provider lock-in, having no dependencies, maximum viem compatibility, and a small bundle size. permissionless.js also provides high-level support for the major ERC-4337 smart accounts, including Safe, Kernel, Biconomy, and SimpleAccount.</HomePage.Description>
+  <HomePage.Description>permissionless.js is a TypeScript library built on viem for building with ERC-4337 smart accounts, bundlers, paymasters, and user operations. The core focuses are avoiding provider lock-in, having no dependencies, maximum viem compatibility, and a small bundle size. permissionless.js also provides high-level support for the major ERC-4337 smart accounts, including Safe, Kernel, Biconomy, SimpleAccount, TrustWallet and LightAccount.</HomePage.Description>
   <HomePage.Buttons>
     <HomePage.Button href="/permissionless/tutorial/tutorial-1" variant="accent">Get started</HomePage.Button>
     <HomePage.Button href="https://github.com/pimlicolabs/permissionless.js">GitHub</HomePage.Button>
@@ -57,7 +57,7 @@ opReceipt!.actualGasUsed
 
 # Features
 
-- **High-level smart account support**: We support a high-level API for deploying and managing smart accounts, including some of the most popular implementations ([Safe](https://safe.global), [Kernel](https://zerodev.app), [Biconomy](https://biconomy.io), etc.)
+- **High-level smart account support**: We support a high-level API for deploying and managing smart accounts, including some of the most popular implementations ([Safe](https://safe.global), [Kernel](https://zerodev.app), [Biconomy](https://biconomy.io), [TrustWallet](https://trustwallet.com/swift), etc.)
 - **Bundler support**: We support all bundler actions following [ERC-4337](https://eips.ethereum.org/EIPS/eip-4337#rpc-methods-eth-namespace).
 - **Gas sponsorship**: We support paymaster actions to allow you to easily sponsor gas fees.
 - **User Operation utility functions**: We provide many low-level utility functions useful for dealing with User Operations.

--- a/docs/pages/permissionless/reference/accounts/signerToTrustSmartAccount.mdx
+++ b/docs/pages/permissionless/reference/accounts/signerToTrustSmartAccount.mdx
@@ -1,0 +1,65 @@
+# signerToTrustSmartAccount
+
+Creates a Trust Wallet Smart Account instance controlled by a `SmartAccountSigner`.  Check out [this guide](/permissionless/how-to/accounts/use-trustwallet-account) for a complete tutorial.
+
+## Usage
+
+::::code-group
+
+```ts [example.ts]
+import { signerToTrustSmartAccount } from "permissionless/accounts"
+import { publicClient } from "./publicClient"
+import { signer } from "./signer"
+
+const account = await signerToTrustSmartAccount(client, {
+	signer,
+    entryPoint: ENTRYPOINT_ADDRESS_V06,
+	address: "0x..." // optional, only if you are using an already created account
+})
+```
+
+```ts [publicClient.ts]
+// [!include ~/snippets/publicClient.ts:client]
+```
+
+```ts [signer.ts]
+// [!include ~/snippets/signer.ts]
+```
+
+::::
+
+## Returns
+
+- **Type:** `TrustSmartAccount`
+
+The Trust smart account instance.
+
+## Parameters
+
+### signer
+
+- **Type:** `SmartAccountSigner`
+
+The signer that will be used to sign messages and user operations.
+
+### entryPoint
+
+- **Type:** `Address`
+
+The address of the EntryPoint contract.
+
+### index (optional)
+
+- **Type:** `bigint`
+
+The index (which is basically a salt) that will be used to deploy the smart account. If not provided, `0` will be used.
+
+### address (optional)
+
+- **Type:** `Address`
+
+:::warning
+If you provide an address, the smart account can not be deployed. This should be used if you want to interact with an existing smart account.
+:::
+
+The address of the smart account. If not provided, the determinstic smart account address will be used.

--- a/docs/snippets/accounts/trustwallet.ts
+++ b/docs/snippets/accounts/trustwallet.ts
@@ -1,0 +1,101 @@
+// [!region imports]
+import { ENTRYPOINT_ADDRESS_V07, createSmartAccountClient } from "permissionless"
+import { signerToTrustSmartAccount } from "permissionless/accounts"
+import {
+	createPimlicoBundlerClient,
+	createPimlicoPaymasterClient,
+} from "permissionless/clients/pimlico"
+import { createPublicClient, getContract, http, parseEther } from "viem"
+import { sepolia } from "viem/chains"
+// [!endregion imports]
+
+// [!region clients]
+export const publicClient = createPublicClient({
+	transport: http("https://rpc.ankr.com/eth_sepolia"),
+})
+
+export const paymasterClient = createPimlicoPaymasterClient({
+	transport: http("https://api.pimlico.io/v2/sepolia/rpc?apikey=API_KEY"),
+	entryPoint: ENTRYPOINT_ADDRESS_V07,
+})
+
+export const pimlicoBundlerClient = createPimlicoBundlerClient({
+	transport: http("https://api.pimlico.io/v2/sepolia/rpc?apikey=API_KEY"),
+	entryPoint: ENTRYPOINT_ADDRESS_V07,
+})
+// [!endregion clients]
+
+// [!region signer]
+import { privateKeyToAccount } from "viem/accounts"
+
+const signer = privateKeyToAccount("0xPRIVATE_KEY")
+// [!endregion signer]
+
+// [!region smartAccount]
+const trustAccount = await signerToTrustSmartAccount(publicClient, {
+	entryPoint: ENTRYPOINT_ADDRESS_V07,
+	signer: signer,
+	index: 0n, // optional
+	address: "0x...", // optional, only if you are using an already created account
+})
+// [!endregion smartAccount]
+
+// [!region smartAccountClient]
+const smartAccountClient = createSmartAccountClient({
+	account: trustAccount,
+	entryPoint: ENTRYPOINT_ADDRESS_V06,
+	chain: sepolia,
+	bundlerTransport: http("https://api.pimlico.io/v2/sepolia/rpc?apikey=API_KEY"),
+	middleware: {
+		sponsorUserOperation: paymasterClient.sponsorUserOperation, // optional
+		gasPrice: async () => (await pimlicoBundlerClient.getUserOperationGasPrice()).fast, // if using pimlico bundler
+	},
+})
+// [!endregion smartAccountClient]
+
+// [!region submit]
+const txHash_$1 = await smartAccountClient.sendTransaction({
+	to: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+	value: parseEther("0.1"),
+})
+// [!endregion submit]
+
+// [!region submitNft]
+const nftAbi = [
+	{
+		inputs: [],
+		name: "mint",
+		outputs: [],
+		stateMutability: "nonpayable",
+		type: "function",
+	},
+] as const
+
+const nftContract = getContract({
+	address: "0xFBA3912Ca04dd458c843e2EE08967fC04f3579c2",
+	abi: nftAbi,
+	client: {
+		public: publicClient,
+		wallet: smartAccountClient,
+	},
+})
+
+const txHash_$2 = await nftContract.write.mint()
+// [!endregion submitNft]
+
+// [!region submitBatch]
+const txHash_$3 = await smartAccountClient.sendTransactions({
+	transactions: [
+		{
+			to: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+			value: parseEther("0.1"),
+			data: "0x",
+		},
+		{
+			to: "0x1440ec793aE50fA046B95bFeCa5aF475b6003f9e",
+			value: parseEther("0.1"),
+			data: "0x1234",
+		},
+	],
+})
+// [!endregion submitBatch]

--- a/docs/snippets/accounts/trustwallet.ts
+++ b/docs/snippets/accounts/trustwallet.ts
@@ -1,5 +1,5 @@
 // [!region imports]
-import { ENTRYPOINT_ADDRESS_V07, createSmartAccountClient } from "permissionless"
+import { ENTRYPOINT_ADDRESS_V06, createSmartAccountClient } from "permissionless"
 import { signerToTrustSmartAccount } from "permissionless/accounts"
 import {
 	createPimlicoBundlerClient,
@@ -16,12 +16,12 @@ export const publicClient = createPublicClient({
 
 export const paymasterClient = createPimlicoPaymasterClient({
 	transport: http("https://api.pimlico.io/v2/sepolia/rpc?apikey=API_KEY"),
-	entryPoint: ENTRYPOINT_ADDRESS_V07,
+	entryPoint: ENTRYPOINT_ADDRESS_V06,
 })
 
 export const pimlicoBundlerClient = createPimlicoBundlerClient({
 	transport: http("https://api.pimlico.io/v2/sepolia/rpc?apikey=API_KEY"),
-	entryPoint: ENTRYPOINT_ADDRESS_V07,
+	entryPoint: ENTRYPOINT_ADDRESS_V06,
 })
 // [!endregion clients]
 
@@ -33,7 +33,7 @@ const signer = privateKeyToAccount("0xPRIVATE_KEY")
 
 // [!region smartAccount]
 const trustAccount = await signerToTrustSmartAccount(publicClient, {
-	entryPoint: ENTRYPOINT_ADDRESS_V07,
+	entryPoint: ENTRYPOINT_ADDRESS_V06,
 	signer: signer,
 	index: 0n, // optional
 	address: "0x...", // optional, only if you are using an already created account

--- a/docs/snippets/signers/accounts/trustSmartAccount.ts
+++ b/docs/snippets/signers/accounts/trustSmartAccount.ts
@@ -1,0 +1,19 @@
+const smartAccountSigner = privateKeyToAccount(generatePrivateKey())
+
+import { ENTRYPOINT_ADDRESS_V06 } from "permissionless"
+// [!region main]
+import { signerToTrustSmartAccount } from "permissionless/accounts"
+import { createPublicClient, http } from "viem"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
+import { sepolia } from "viem/chains"
+
+export const publicClient = createPublicClient({
+	transport: http("https://rpc.ankr.com/eth_sepolia"),
+	chain: sepolia,
+})
+
+const smartAccount = await signerToTrustSmartAccount(publicClient, {
+	signer: smartAccountSigner,
+	entryPoint: ENTRYPOINT_ADDRESS_V06,
+})
+// [!endregion main]

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -211,6 +211,7 @@ export const permissionlessSidebar = [
           { text: "How to use a SimpleAccount", link: "/permissionless/how-to/accounts/use-simple-account" },
           { text: "How to use a Biconomy account", link: "/permissionless/how-to/accounts/use-biconomy-account" },
           { text: "How to use a LightAccount", link: "/permissionless/how-to/accounts/use-light-account" },
+          { text: "How to use a Trust Wallet account", link: "/permissionless/how-to/accounts/use-trustwallet-account" },
         ]
       },
       {
@@ -261,6 +262,7 @@ export const permissionlessSidebar = [
           { text: "signerToSafeSmartAccount", link: "/permissionless/reference/accounts/signerToSafeSmartAccount" },
           { text: "signerToKernelSmartAccount", link: "/permissionless/reference/accounts/signerToKernelSmartAccount" },
           { text: "signerToLightSmartAccount", link: "/permissionless/reference/accounts/signerToLightSmartAccount" },
+          { text: "signerToTrustSmartAccount", link: "/permissionless/reference/accounts/signerToTrustSmartAccount" },
         ]
       },
       {


### PR DESCRIPTION
# PR Summary

[permissionless@1.3.1](https://github.com/pimlicolabs/permissionless.js/releases/tag/permissionless%400.1.31) added support for Trust Wallet's Smart Account implementation, Barz.

This PR adds relevant docs to help SDK users get guidance on how to use the Trust Wallet's Smart Account through permissionless.