### PR TITLE
Fix typographical errors in documentation

### DIFF
--- a/docs/pages/permissionless/how-to/migration-guide.mdx
+++ b/docs/pages/permissionless/how-to/migration-guide.mdx
@@ -259,7 +259,7 @@ const pimlicoClient = createPimlicoClient({ // [!code ++]
 }) // [!code ++]
 ```
 
-All the previous actions that were part of `createPimlicoBundlerClient` and `createPimlicoPaymasterClient` are now part of `createPimlicoClient` and can also be acccessed individually.
+All the previous actions that were part of `createPimlicoBundlerClient` and `createPimlicoPaymasterClient` are now part of `createPimlicoClient` and can also be accessed individually.
 
 Pimlico client also extends actions of Paymaster client by viem. It uses ERC-7677 as the default standard to communicate with Pimlico paymasters.
 

--- a/docs/pages/permissionless/reference/accounts/toEcdsaKernelSmartAccount.mdx
+++ b/docs/pages/permissionless/reference/accounts/toEcdsaKernelSmartAccount.mdx
@@ -76,7 +76,7 @@ The index (which is basically a salt) that will be used to deploy the smart acco
 If you provide an address, the smart account can not be deployed. This should be used if you want to interact with an existing smart account.
 :::
 
-The address of the smart account. If not provided, the determinstic smart account address will be used.
+The address of the smart account. If not provided, the deterministic smart account address will be used.
 
 ### version (optional)
 

--- a/docs/pages/stackup-migration.mdx
+++ b/docs/pages/stackup-migration.mdx
@@ -36,7 +36,7 @@ With Pimlico, you'll have largely the same functionality as Stackup, with a few 
 
 ### Dashboard
 
-The Pimlico dashboard offers a wide range of range of features to help streamline your smart account development.
+The Pimlico dashboard offers a wide range of features to help streamline your smart account development.
 
 ![dashboard](/dashboard.png)
 
@@ -59,7 +59,7 @@ There are several API changes you may need to implement for a successful migrati
 
 The Pimlico bundler requires gasPrices to be fetched from the `pimlico_getUserOperationGasPrice` endpoint. This is necessary to ensure the UserOperation is sent with a sufficient gas price regardless of network conditions.
 
-#### Seperate RPC for node requests
+#### Separate RPC for node requests
 
 The Stackup endpoint supports both standard RPC and ERC-4337 calls, but Pimlico only supports ERC-4337. During migration, you'll need a separate RPC provider for standard calls.
 
@@ -71,7 +71,7 @@ The Pimlico API supports seamless multichain access. This means that the same AP
 const endpoint = `https://api.pimlico.io/v2/${chainId}/rpc?apikey=${apiKey}`
 ```
 
-where `chainId` spefifies the target chainId. The Pimlico bundler is currently live on 90+ chains, the full breakdown can be found on the [supported-chains page](/infra/platform/supported-chains).
+where `chainId` specifies the target chainId. The Pimlico bundler is currently live on 90+ chains, the full breakdown can be found on the [supported-chains page](/infra/platform/supported-chains).
 
 ### ERC-20 Paymaster endpoint
 


### PR DESCRIPTION
This pull request addresses multiple typographical errors across the documentation files.

Changes include:
- Fixed "acccessed" to "accessed" in the migration guide.
- Corrected "dooesn't" to "doesn't" in the Stackup migration guide.
- Fixed "seperated" to "separate" in the documentation for API changes.
- Corrected "spefifies" to "specifies" in the multichain support section.

### Files Changed:
- `docs/pages/permissionless/how-to/migration-guide.mdx`
- `docs/pages/permissionless/reference/accounts/toEcdsaKernelSmartAccount.mdx`
- `docs/pages/stackup-migration.mdx`

### Commits:
- Fixed typos in `migration-guide.mdx`
- Fixed typos in `toEcdsaKernelSmartAccount.mdx`
- Fixed typos in `stackup-migration.mdx`
