### PR TITLE
fix: Fix typo in "demoniation" to "denomination" Update calculate-cos…

### DIFF
--- a/docs/snippets/erc20-paymaster/calculate-costs.ts
+++ b/docs/snippets/erc20-paymaster/calculate-costs.ts
@@ -94,10 +94,10 @@ const userOperationMaxCost = userOperationMaxGas * op.maxFeePerGas
 // [!endregion calculateMaxCost]
 
 // [!region calculateCostInToken]
-// represents the userOperation's max cost in demoniation of wei
+// represents the userOperation's max cost in denomination of wei
 const maxCostInWei = userOperationMaxCost + postOpGas * op.maxFeePerGas
 
-// represents the userOperation's max cost in token demoniation (wei)
+// represents the userOperation's max cost in token denomination (wei)
 const maxCostInTokenRaw = (maxCostInWei * exchangeRate) / BigInt(1e18)
 
 // represents the userOperation's max cost in token (human readable format)


### PR DESCRIPTION
I noticed a typo in the word "demoniation" and corrected it to the proper spelling, "denomination."
This should resolve any confusion or issues related to the misspelling.