### PR TITLE
Fix typos in documentation and code snippets

### DIFF
--- a/docs/pages/permissionless/how-to/testing/build-bear.mdx
+++ b/docs/pages/permissionless/how-to/testing/build-bear.mdx
@@ -1,6 +1,6 @@
 # Testing with BuildBear Sandboxes
 
-This guide introduces how to setup a BuildBear Sandbox with for testing the Alto bundler and a mock paymaster. We will be using viem and permissionless to interact with the sandbox enviornment.
+This guide introduces how to setup a BuildBear Sandbox with for testing the Alto bundler and a mock paymaster. We will be using viem and permissionless to interact with the sandbox environment.
 
 ## Overview
 

--- a/docs/pages/permissionless/v0_1/reference/utils/getRequiredPrefund.mdx
+++ b/docs/pages/permissionless/v0_1/reference/utils/getRequiredPrefund.mdx
@@ -27,7 +27,7 @@ const requiredPrefund = getRequiredPrefund({
 
 `BigInt`
 
-The requied prefund in wei.
+The required prefund in wei.
 
 ## Parameters
 

--- a/docs/snippets/v0_1/how-to/parallel-transactions.ts
+++ b/docs/snippets/v0_1/how-to/parallel-transactions.ts
@@ -33,7 +33,7 @@ export const smartAccountClient = createSmartAccountClient({
 // [!endregion client]
 
 // [!region multiple-transactions]
-const trasnactionHash = await smartAccountClient.sendTransactions({
+const transactionHash = await smartAccountClient.sendTransactions({
 	transactions: [
 		{
 			to: "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",


### PR DESCRIPTION
This PR fixes several typos across documentation and code:

- Corrects "enviornment" to "environment" in build-bear.mdx
- Fixes "requied" to "required" in getRequiredPrefund.mdx documentation
- Corrects "trasnactionHash" to "transactionHash" variable name in parallel-transactions.ts

These changes improve code consistency and documentation readability.