### PR TITLE
Update links for MetaMaskSmartAccount

### DIFF
--- a/docs/pages/guides/how-to/accounts/use-metamask-account.mdx
+++ b/docs/pages/guides/how-to/accounts/use-metamask-account.mdx
@@ -1,10 +1,10 @@
 # How to use Metamask delegation toolkit with permissionless.js
 
 :::info
-Metamask maintains their own in-house SDK built closely on top of permissionless.js that you can use for the account system while still plugging in all the other components from permissionless.js. Take a look at [their documentation](https://docs.gator.metamask.io/how-to/send-user-operation) for more information.
+Metamask maintains their own in-house SDK built closely on top of permissionless.js that you can use for the account system while still plugging in all the other components from permissionless.js. Take a look at [their documentation](https://docs.metamask.io/delegation-toolkit/how-to/send-user-operation) for more information.
 :::
 
-[Metamask Delegation Toolkit](https://docs.gator.metamask.io/get-started/delegation-toolkit-quickstart/) is a **smart account** that supports delegation of the smart account to another signer with granular permission sharing. It is build over [ERC-7710](https://eip.tools/eip/7710) and [ERC-7715](https://eip.tools/eip/7715) to support a standardized minimal interface. Requesting ERC-7715 permissions and redeeming ERC-7710 delegations are experimental features.
+[Metamask Delegation Toolkit](https://docs.metamask.io/delegation-toolkit/get-started/quickstart) is a **smart account** that supports delegation of the smart account to another signer with granular permission sharing. It is build over [ERC-7710](https://eip.tools/eip/7710) and [ERC-7715](https://eip.tools/eip/7715) to support a standardized minimal interface. Requesting ERC-7715 permissions and redeeming ERC-7710 delegations are experimental features.
 
 You can have two types of account in Metamask Delegation Toolkit:
 
@@ -62,7 +62,7 @@ For example, to create a signer based on a private key:
 ### Create the Metamask delegator account
 
 :::info
-For a full list of options for creating a Metamask account, take a look at the Metamask's documentation page for [`toMetaMaskSmartAccount`](https://docs.gator.metamask.io/how-to/create-delegator-account).
+For a full list of options for creating a Metamask account, take a look at the Metamask's documentation page for [`toMetaMaskSmartAccount`](https://docs.metamask.io/delegation-toolkit/how-to/create-smart-account).
 :::
 
 With a signer, you can create a Metamask account as such:
@@ -133,7 +133,7 @@ For example, to create a signer based on a private key:
 ### Create the Metamask delegate account
 
 :::info
-For a full list of options for creating a Metamask account, take a look at the Metamask's documentation page for [`toMetaMaskSmartAccount`](https://docs.gator.metamask.io/how-to/create-delegator-account).
+For a full list of options for creating a Metamask account, take a look at the Metamask's documentation page for [`toMetaMaskSmartAccount`](https://docs.metamask.io/delegation-toolkit/how-to/create-smart-account).
 :::
 
 With a delegate signer, you can create a Metamask delegate account as such:


### PR DESCRIPTION
## Description
We’ve recently moved the Delegation Toolkit documentation to [docs.metamask.io/delegation-toolkit](https://docs.metamask.io/delegation-toolkit), which may cause some existing links to break.