### PR TITLE
fix: alto self host config invalid key

### DIFF
--- a/docs/pages/references/bundler/self-host.mdx
+++ b/docs/pages/references/bundler/self-host.mdx
@@ -32,7 +32,7 @@ Once all the prerequisite conditions are met, Alto can be started using
 ./alto run
     --entrypoints "0x0000000071727De22E5E9d8BAf0edAc6f37da032,0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
     --executor-private-keys "0x34e9a7...,0xb08d34...,0x163cbb..."
-    --utility-private-keys "0xe768f1..."
+    --utility-private-key "0xe768f1..."
     --rpc-url "http://localhost:8545"
     --safe-mode false
 ```
@@ -47,7 +47,7 @@ Create and setup `alto-config.json`
 {
     "entrypoints": "0x0000000071727De22E5E9d8BAf0edAc6f37da032,0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
     "executor-private-keys": "0x34e9a7...,0xb08d34...,0x163cbb...",
-    "utility-private-keys": "0xe768f1...",
+    "utility-private-key": "0xe768f1...",
     "rpc-url": "http://localhost:8545",
     "safe-mode": false
 }


### PR DESCRIPTION
Partially Fixes #101 

Updated Alto self-host to use `utility-private-key` instead of `utility-private-keys`.