### PR TITLE
docs(lit-protocol): update Lit Protocol documentation link

### DIFF
--- a/docs/pages/guides/how-to/signers/lit-protocol.mdx
+++ b/docs/pages/guides/how-to/signers/lit-protocol.mdx
@@ -3,7 +3,7 @@
 This how-to guide will walk you through the steps to integrate Lit Protocol's OTP sign-in with email, SMS, and Whatsapp with a smart account whose user operations are relayed and sponsored by Pimlico.
 
 :::info
-Lit Protocol is an Authentication solution that lets you create and manage distributed cryptographic key-pairs for condition-based encryption and programmatic signing. A decentralized key management network, Lit can be used in place of centralized key custodians and other key management solutions. For more information on how Lit Protocol works, visit [their documentation page](https://developer.litprotocol.com/learning-lit/how-it-works).
+Lit Protocol is an Authentication solution that lets you create and manage distributed cryptographic key-pairs for condition-based encryption and programmatic signing. A decentralized key management network, Lit can be used in place of centralized key custodians and other key management solutions. For more information on how Lit Protocol works, visit [their documentation page](https://developer.litprotocol.com/architecture).
 :::
 
 [Stytch](https://stytch.com/) will be used to manage the OTP authentication flow.

--- a/docs/pages/references/permissionless/how-to/signers/lit-protocol.mdx
+++ b/docs/pages/references/permissionless/how-to/signers/lit-protocol.mdx
@@ -3,7 +3,7 @@
 This how-to guide will walk you through the steps to integrate Lit Protocol's OTP sign-in with email, SMS, and Whatsapp with a smart account whose user operations are relayed and sponsored by Pimlico.
 
 :::info
-Lit Protocol is an Authentication solution that lets you create and manage distributed cryptographic key-pairs for condition-based encryption and programmatic signing. A decentralized key management network, Lit can be used in place of centralized key custodians and other key management solutions. For more information on how Lit Protocol works, visit [their documentation page](https://developer.litprotocol.com/learning-lit/how-it-works).
+Lit Protocol is an Authentication solution that lets you create and manage distributed cryptographic key-pairs for condition-based encryption and programmatic signing. A decentralized key management network, Lit can be used in place of centralized key custodians and other key management solutions. For more information on how Lit Protocol works, visit [their documentation page](https://developer.litprotocol.com/architecture).
 :::
 
 [Stytch](https://stytch.com/) will be used to manage the OTP authentication flow.

--- a/docs/pages/references/permissionless/v0_1/how-to/signers/lit-protocol.mdx
+++ b/docs/pages/references/permissionless/v0_1/how-to/signers/lit-protocol.mdx
@@ -7,7 +7,7 @@ import VersionWarning from "../../../VersionWarning"
 This how-to guide will walk you through the steps to integrate Lit Protocol's OTP sign-in with email, SMS, and Whatsapp with a smart account whose user operations are relayed and sponsored by Pimlico.
 
 :::info
-Lit Protocol is an Authentication solution that lets you create and manage distributed cryptographic key-pairs for condition-based encryption and programmatic signing. A decentralized key management network, Lit can be used in place of centralized key custodians and other key management solutions. For more information on how Lit Protocol works, visit [their documentation page](https://developer.litprotocol.com/learning-lit/how-it-works).
+Lit Protocol is an Authentication solution that lets you create and manage distributed cryptographic key-pairs for condition-based encryption and programmatic signing. A decentralized key management network, Lit can be used in place of centralized key custodians and other key management solutions. For more information on how Lit Protocol works, visit [their documentation page](https://developer.litprotocol.com/architecture).
 :::
 
 [Stytch](https://stytch.com/) will be used to manage the OTP authentication flow.


### PR DESCRIPTION
- Updated outdated documentation URL from learning-lit/how-it-works to architecture

- Applied fix across all three Lit Protocol guide versions
