### PR TITLE
docs(pricing): add pimlico_getTokenQuotesAndEstimateGas endpoint

### DIFF
--- a/docs/pages/guides/pricing.mdx
+++ b/docs/pages/guides/pricing.mdx
@@ -40,6 +40,7 @@ The cost of individual API requests is measured in credits, with the breakdown o
 | pm_sponsorUserOperation             | 500     |
 | eth_sendUserOperation               | 500     |
 | pm_getPaymasterData                 | 300     |
+| pimlico_getTokenQuotesAndEstimateGas | 300     |
 | pm_getPaymasterStubData             | 200     |
 | eth_estimateUserOperationGas        | 200     |
 | pimlico_getTokenQuotes              | 100     |


### PR DESCRIPTION
- Added new API method to pricing reference table with 300 credit cost
