### PR TITLE
fix(layout): keep gutters in viewport

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,1 +1,10 @@
 @import "tailwindcss";
+
+/* Keep fixed side gutters within the viewport when the banner is visible. */
+@media screen and (min-width: 1081px) {
+    .vocs_DocsLayout_gutterLeft,
+    .vocs_DocsLayout_gutterRight {
+        bottom: 0;
+        height: auto !important;
+    }
+}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,8 +1,11 @@
 @import "tailwindcss";
 
-/* Keep fixed side gutters within the viewport when the banner is visible. */
+/*
+ * Vocs still sizes the desktop right gutter as 100vh while also offsetting it by
+ * the fixed banner height, which pushes the bottom of the outline off-screen.
+ * Limit this override to desktop because the gutter layout changes below 1081px.
+ */
 @media screen and (min-width: 1081px) {
-    .vocs_DocsLayout_gutterLeft,
     .vocs_DocsLayout_gutterRight {
         bottom: 0;
         height: auto !important;


### PR DESCRIPTION
- Adjust fixed docs gutters on wide screens

- Prevent gutter overflow when the banner is visible
