### PR TITLE
docs(why-pimlico): add soc2 messaging

### DIFF
--- a/docs/pages/guides/why-pimlico/enterprise.mdx
+++ b/docs/pages/guides/why-pimlico/enterprise.mdx
@@ -28,7 +28,7 @@ In addition to the built in customization features, we can work with you to:
 
 ## Reliable and secure
 
-When you build with Pimlico, you can trust that you are building on a dependable, battle-tested platform. We pride ourselves in our [exceptional uptime](https://status.pimlico.io) and will provide you with a comprehensive uptime SLA. Our servers are monitored 24/7, and we have a dedicated team of engineers who are always ready to respond to any issues that may arise. 
+Pimlico is SOC 2 Type 1 certified, giving enterprises confidence in our security controls. When you build with Pimlico, you can trust that you are building on a dependable, battle-tested platform. We pride ourselves in our [exceptional uptime](https://status.pimlico.io) and will provide you with a comprehensive uptime SLA. Our servers are monitored 24/7, and we have a dedicated team of engineers who are always ready to respond to any issues that may arise. 
 
 When it comes to security, due to the nature of the type of infrastructure we provide, even in a worst case scenario we are never directly or indirectly in custody of user funds. Despite this, our ERC-20 paymasters [have been audited](/references/paymaster/erc20-paymaster/faqs#has-pimlicos-erc-20-paymaster-been-audited) by OpenZeppelin and QuantStamp, some of the best security firms in the space.
 

--- a/docs/pages/guides/why-pimlico/startups.mdx
+++ b/docs/pages/guides/why-pimlico/startups.mdx
@@ -14,6 +14,7 @@ This means you can expect features such as:
 - [Sponsorship policies](/guides/how-to/sponsorship-policies), letting you set fine-grained conditions for which user operations you would like to sponsor, including global, per user, and per user operation spending limits, custom webhook validation, and more
 - A [gas grants platform](/guides/how-to/gas-programs/gas-program), letting you apply for gas grants from our partners to help you get started with smart accounts without having to pay for gas
 - Our permissionless and [audited](/references/paymaster/erc20-paymaster/faqs#has-pimlicos-erc-20-paymaster-been-audited) [ERC-20 paymasters], letting your users pay with ERC-20 tokens like USDC for their transaction fees
+- SOC 2 Type 1 certified infrastructure, giving you confidence as you scale toward production
 - Multi-chain support, letting you build with smart accounts on [over 70+ chains](/guides/supported-chains)
 - API key authentication and authorization options, letting you control how your bundlers and paymasters can be accessed
 - Flexible payment methods, letting you pay for your usage with a credit card, bank transfer, crypto


### PR DESCRIPTION
- Add SOC 2 Type 1 positioning to enterprise and startup pages

- Reinforce security and scaling confidence in why-pimlico messaging
