### PR TITLE
ci: use pnpm 10 and frozen lockfile for docs-data-updater install

### DIFF
--- a/.github/workflows/update-docs-data.yaml
+++ b/.github/workflows/update-docs-data.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
           run_install: false
       
       - name: Get current date and time
@@ -45,7 +45,7 @@ jobs:
       
       - name: Install dependencies in docs-data-updater
         working-directory: docs-data-updater
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       
       - name: Build docs-data-updater
         working-directory: docs-data-updater


### PR DESCRIPTION
pnpm 8 cannot read docs-data-updater's lockfileVersion 9.0 lockfile, so it
silently ignored it and re-resolved all dependencies. A fresh resolve pulled
in ox 0.14.29 (via viem), whose shipped TypeScript source fails to compile,
breaking the build step. pnpm 10 respects the committed lockfile (ox 0.6.9,
typescript 5.8.3), and --frozen-lockfile makes any future lockfile mismatch
fail loudly instead of silently re-resolving.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
