### PR TITLE
docs(accounts): pin kernel audit links

### DIFF
--- a/docs/pages/guides/how-to/accounts/comparison.mdx
+++ b/docs/pages/guides/how-to/accounts/comparison.mdx
@@ -35,7 +35,7 @@ permissionless.js supports 8 types of accounts. Below is an overview of each acc
   - Specify conditions for actions.
   - Configure what actions can be performed.
 - **Usage Stats**: ~133k Kernel v3 and 771k Kernel v2 accounts created in the last 6 months ([source](https://stats.pimlico.io/accounts)).
-- **Audits**: Audited by [ChainLight](https://github.com/zerodevapp/kernel/blob/dev/audits/chainlight_v3_0.pdf) and [Kalos](https://github.com/zerodevapp/kernel/tree/dev/audits).
+- **Audits**: Audited by [ChainLight](https://github.com/zerodevapp/kernel/blob/737db3123165d6009c9261dc98e149a3fdd82f97/audits/chainlight_v3_0.pdf) and [Kalos](https://github.com/zerodevapp/kernel/tree/737db3123165d6009c9261dc98e149a3fdd82f97/audits).
 
 ## 3. **Nexus**
 

--- a/docs/pages/references/permissionless/how-to/accounts/comparison.mdx
+++ b/docs/pages/references/permissionless/how-to/accounts/comparison.mdx
@@ -35,7 +35,7 @@ permissionless.js supports 8 types of accounts. Below is an overview of each acc
   - Specify conditions for actions.
   - Configure what actions can be performed.
 - **Usage Stats**: ~133k Kernel v3 and 771k Kernel v2 accounts created in the last 6 months ([source](https://stats.pimlico.io/accounts)).
-- **Audits**: Audited by [ChainLight](https://github.com/zerodevapp/kernel/blob/dev/audits/chainlight_v3_0.pdf) and [Kalos](https://github.com/zerodevapp/kernel/tree/dev/audits).
+- **Audits**: Audited by [ChainLight](https://github.com/zerodevapp/kernel/blob/737db3123165d6009c9261dc98e149a3fdd82f97/audits/chainlight_v3_0.pdf) and [Kalos](https://github.com/zerodevapp/kernel/tree/737db3123165d6009c9261dc98e149a3fdd82f97/audits).
 
 ## 3. **Nexus**
 


### PR DESCRIPTION
- Updated kernel audit references to use a fixed commit hash

- Kept guide and reference account comparison pages in sync
